### PR TITLE
Add prefix config option to allow a diagram prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ChangeLog
 
+## [1.0.5] - 2022-12-22
+
+### Update
+
+- Allows a configurable prefix to the diagram type to support compatibility with other tools, such as the mdbook addon for kroki.
+
 ## [1.0.2] - 2022-08-05
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-kroki",
-  "version": "1.0.2",
+  "version": "1.0.5",
   "displayName": "Markdown Kroki",
   "description": "Adds Kroki diagram support to VS Code's builtin markdown preview",
   "icon": "resources/logo.png",
@@ -47,7 +47,6 @@
   },
   "activationEvents": [],
   "main": "./dist/index.js",
-  "browser": "./dist/web/index.js",
   "categories": [
     "Other"
   ],
@@ -55,10 +54,15 @@
     "configuration": {
       "title": "markdown-kroki",
       "properties": {
-        "url": {
+        "markdown-kroki.url": {
           "type": "string",
           "description": "The URL of the Kroki server",
           "default": "https://kroki.io"
+        },
+        "markdown-kroki.prefix": {
+          "type": "string",
+          "description": "The prefix to add in front of the diagram type name, eg \"kroki-\"",
+          "default": ""
         }
       }
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,31 @@
 import pako from "pako";
 import { workspace } from "vscode";
+import * as vscode from 'vscode';
 
 export function activate() {
   return {
     extendMarkdownIt(md) {
       const config = workspace.getConfiguration("markdown-kroki");
+
       const fence = md.renderer.rules.fence.bind(md.renderer.rules);
+      const diagramPrefix = config.get<string>("prefix", "").toLowerCase();
+      const url = config.get<string>("url", "https://kroki.io");
+    
       md.renderer.rules.fence = (tokens, idx, options, env, slf) => {
-        const token = tokens[idx];
-        if (supportedDiagramTypes.includes(token.info.toLowerCase())) {
+        const token = tokens[idx]
+
+        const diagramType = (() => {
+          var tokenName = token.info.toLowerCase();
+          if (tokenName.indexOf(diagramPrefix) == 0) {
+            return tokenName.slice(diagramPrefix.length);
+          } else {
+            return ""; // Prefix not found, so not our token.
+          }
+        })();
+
+        if (supportedDiagramTypes.includes(diagramType)) {
           const encodedDiagram = encodeDiagram(token.content.trim());
-          return `<p><img src="${config.get("url", "https://kroki.io")}/${
-            token.info
-          }/svg/${encodedDiagram}"></p>`;
+          return `<p><img src="${url}/${diagramType}/svg/${encodedDiagram}"></p>`;
         }
         return fence(tokens, idx, options, env, slf);
       };


### PR DESCRIPTION
Tools like this: https://lib.rs/crates/mdbook-kroki-preprocessor also support kroki diagrams inside fenced code blocks.  But in this case, they use a prefix in front of the diagram name.  This PR adds an optional prefix parameter which allows easy compatibility with tools like this.

There was also a bug with handling of config values, so I had to fix that as well.