### PR TITLE
Add DBML & D2 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 .DS_Store
 dist
 *.vsix
+.idea

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Supported formats:
 - bpmn
 - bytefield
 - c4plantuml
+- d2
 - dbml
 - diagramsnet
 - ditaa

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Supported formats:
 - bpmn
 - bytefield
 - c4plantuml
+- dbml
 - diagramsnet
 - ditaa
 - erd

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "bpmn",
     "bytefield",
     "c4plantuml",
+    "dbml",
     "diagramsnet",
     "ditaa",
     "erd",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "bpmn",
     "bytefield",
     "c4plantuml",
+    "d2",
     "dbml",
     "diagramsnet",
     "ditaa",

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ const supportedDiagramTypes = [
   "bpmn",
   "bytefield",
   "c4plantuml",
+  "d2",
   "dbml",
   "diagramsnet",
   "ditaa",

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ const supportedDiagramTypes = [
   "bpmn",
   "bytefield",
   "c4plantuml",
+  "dbml",
   "diagramsnet",
   "ditaa",
   "erd",


### PR DESCRIPTION
Since https://github.com/yuzutech/kroki/pull/1432, kroki (either from kroki.io or from up-to-date self-hosted instance) can convert DBML diagrams (see https://www.dbml.org/home/) to SVG using dbml-renderer (https://github.com/softwaretechnik-berlin/dbml-renderer).

This pull request only aims at forwarding this new support.