### PR TITLE
Allow self signed certificates for kroki

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,11 @@
           "type": "string",
           "description": "The prefix to add in front of the diagram type name, eg \"kroki-\"",
           "default": ""
-        }
+        },
+        "markdown-kroki.allowSelfSignedHost": {
+          "type": "boolean",
+          "description": "Set to true when SSL cert for Kroki server is self-signed",
+          "default": false}
       }
     },
     "markdown.markdownItPlugins": true


### PR DESCRIPTION
When kroki is self-hosted, a self-signed certificate may be in the SSL certificate chain. This update allows a flag to be set to allow the self-signed certificate.